### PR TITLE
Rewrite bc.getCommands.  

### DIFF
--- a/leobridgeserver.py
+++ b/leobridgeserver.py
@@ -1416,6 +1416,35 @@ class LeoBridgeIntegController:
         return w_ap
 
 
+    def getLanguageAtPosition(self, p):
+        """
+        Return the language in effect at position p.
+        
+        This is always a lowercase language name, never None.
+        """
+        c, g = self.commander, self.g
+        aList = g.get_directives_dict_list(p)
+        d = g.scanAtCommentAndAtLanguageDirectives(aList)
+        #
+        # Félix, I'm not sure what the default, if any, should be.
+        #
+        if 1:  # Exactly as in Leo.
+            language = (
+                d and d.get('language') or
+                g.getLanguageFromAncestorAtFileNode(p) or
+                c.config.getString('target-language') or
+                'python'
+            )
+            return self.sendLeoBridgePackage("language", language.lower())
+        else:  # Return both an explicit language and a default language.
+            language = d and d.get('language') or g.getLanguageFromAncestorAtFileNode(p) or 'none'
+            default = c.config.getString('target-language').lower() or 'none'  # or 'typescript' ??
+            result = {
+                'language': language.lower(),
+                'default': default,
+            }
+            return self.sendLeoBridgePackage("result", result)
+            
 def main():
     '''python script for leo integration via leoBridge'''
     global wsHost, wsPort

--- a/leobridgeserver.py
+++ b/leobridgeserver.py
@@ -769,7 +769,7 @@ class LeoBridgeIntegController:
         else:
             d = c.commandsDict  # keys are command names, values are functions.
         result = []
-        for command_name in list(set(d)):  # Weird. Dict keys should be distinct ????
+        for command_name in sorted(d):
             func = d.get(command_name)
             if not func:
                 print('no func:', command_name, flush=True)

--- a/leobridgeserver.py
+++ b/leobridgeserver.py
@@ -755,17 +755,41 @@ class LeoBridgeIntegController:
         return self.outputPNode(self.commander.p)  # return selected node when done
 
     def getCommands(self, p_package):
-        """get command list starting with the prefix string."""
+        """return a list of all commands."""
         c = self.commander
-        # prefix = p_package.get('text', '').strip()  # ? maybe drop the prefix concept entirely
-        commands = sorted(list(c.commandsDict.keys()))
-        # TEMPORARY test restriction : minimum 3 chars and starts with a letter... Edward will fix this ;)
-        commands = [{"label": k, "detail": self._getDocstringForCommand(
-            k)} for k in commands if (len(k) > 3 and k[0].isalpha())]
-        # g.printObj(commands, tag=f"commands for {prefix}") # comment kept for tests, may cleanup later
-        # print('done', flush=True)  # Doesn't help.
-        return self.sendLeoBridgePackage("commands", commands)
-
+            # To do: return only commands that make sense in vs-code.
+        if 0:
+            # Testing. This works: keys are command names, values are functions.
+            d = {
+                'clone-find-all-marked': c.cloneFindAllMarked,
+                'hoist': c.hoist,
+                'dehoist': c.dehoist,
+                'git-diff': c.editFileCommands.gitDiff,
+            }
+        else:
+            d = c.commandsDict  # keys are command names, values are functions.
+        result = []
+        for command_name in list(set(d)):  # Weird. Dict keys should be distinct ????
+            func = d.get(command_name)
+            if not func:
+                print('no func:', command_name, flush=True)
+                continue
+            # Prefer func.__func_name__ to func.__name__: Leo's decorators change func.__name__!
+            func_name = getattr(func, '__func_name__', func.__name__)
+            if not func_name:
+                print('no func_name', command_name, flush=True)
+                continue
+            doc = func.__doc__ or ''
+            result.append({
+                "command_name": command_name, # New, recommended for minibuffer display.
+                "label":  func_name, # should be function_name ?
+                "detail": doc,
+            })
+            # This shows up in the bridge log.
+            # print(f"__doc__: {len(doc):4} {command_name:40} {func_name} ", flush=True)
+            print(f"{func_name} ", flush=True)
+        
+        return self.sendLeoBridgePackage("commands", result)
     def _getDocstringForCommand(self, command_name):
         """get docstring for the given command."""
         func = self._get_commander_method(command_name)


### PR DESCRIPTION
**Important notes**

- This is a much trickier project than I expected.

- Requires rev d946df88 from Leo's devel branch. The checkin log:
  "Support for leoInteg: command decorators inject `__func_name__` attribute to wrapped functions."

- Adds unused "command_name" key in returned dict, containing Leo's command name.
  For example, "git-diff" instead of "gitDiff".
  Imo, Leo's minibuffer should only show such names (git-diff), never the function name (gitDiff).

- All tests of minibuffer commands work as expected.
  However, git-diff fails because the command thinks the working directory is not where we want it. Attempting to set pwd in either console does not work. This might be a bug in Leo's git-diff command.

**To do in python (EKR)**

- Filter out inappropriate commands.
  I am starting to think that perhaps it would be easier to allow only a static set of commands from Leo's core, augmented by most (all?) commands created in plugins. We shall see.

**To do in ts (Félix)**:

- Show command names, not function names, in the minibuffer.
- Present minibuffer commands alphabetically by command name.