### PR TITLE
This fix handles leoserver 'warning(s)' on startup: it just reports the warning. Fixes #262

### DIFF
--- a/leoInteg.leo
+++ b/leoInteg.leo
@@ -7898,16 +7898,27 @@ public startServer(p_leoPythonCommand: string, p_leoEditorPath: string, p_port: 
         // Capture the ERROR channel and set flags on server errors
         if (this._serverProcess &amp;&amp; this._serverProcess.stderr) {
             this._serverProcess.stderr.on("data", (p_data: string) =&gt; {
+                if (p_data.toLocaleLowerCase().includes('warning:')) {
+                    vscode.window.showInformationMessage(
+                        "leoserver issued warning: ",
+                        p_data
+                    );
+                    return;
+                }
                 console.log(`stderr: ${p_data}`);
+
                 this._isStarted = false;
                 if (!this._leoIntegration.activated) {
                     return;
                 }
                 utils.setContext(Constants.CONTEXT_FLAGS.SERVER_STARTED, false);
-                this._serverProcess = undefined;
+
+                this.killServer();
+
                 if (this._rejectPromise) {
                     this._rejectPromise(`stderr: ${p_data}`);
                 }
+
             });
         } else {
             console.error("No stderr");

--- a/src/serverManager.ts
+++ b/src/serverManager.ts
@@ -161,16 +161,27 @@ export class ServerService {
             // Capture the ERROR channel and set flags on server errors
             if (this._serverProcess && this._serverProcess.stderr) {
                 this._serverProcess.stderr.on("data", (p_data: string) => {
+                    if (p_data.toLocaleLowerCase().includes('warning:')) {
+                        vscode.window.showInformationMessage(
+                            "leoserver issued warning: ",
+                            p_data
+                        );
+                        return;
+                    }
                     console.log(`stderr: ${p_data}`);
+
                     this._isStarted = false;
                     if (!this._leoIntegration.activated) {
                         return;
                     }
                     utils.setContext(Constants.CONTEXT_FLAGS.SERVER_STARTED, false);
-                    this._serverProcess = undefined;
+
+                    this.killServer();
+
                     if (this._rejectPromise) {
                         this._rejectPromise(`stderr: ${p_data}`);
                     }
+
                 });
             } else {
                 console.error("No stderr");


### PR DESCRIPTION
Quick and simple fix for the warning by python 3.10 (and further warnings!)