### PR TITLE
Add commodity keybindings Ctrl+Shift+L for revealing the LeoInteg view, with option to turn commodity keybindings off

### DIFF
--- a/leoInteg.leo
+++ b/leoInteg.leo
@@ -3831,6 +3831,18 @@ print('done')
   "type": "boolean",
   "description": "Specifies whether to keep focus in the outline when opening a body pane on the side"
 },
+"leoIntegration.leoCollapseAllShortcut": {
+  "scope": "application",
+  "default": true,
+  "type": "boolean",
+  "description": "Enables the alt+minus keyboard shortcut for collapsing all folders in the Explorer View"
+},
+"leoIntegration.leoActivityViewShortcut": {
+  "scope": "application",
+  "default": true,
+  "type": "boolean",
+  "description": "Enables the Ctrl+Shift+L keyboard shortcut for showing the LeoIntegration view"
+},
 </t>
 <t tx="ekr.20200815123601.40">{
   "view": "leoButtons",
@@ -14053,9 +14065,13 @@ private _bodySaveDeactivate(
 <t tx="felix.20210812004050.1">{
   "command": "workbench.files.action.collapseExplorerFolders",
   "key": "alt+-",
-  "when": "!inSearchEditor &amp;&amp; !sideBarFocus &amp;&amp; resourceScheme == untitled || !inSearchEditor &amp;&amp; !sideBarFocus &amp;&amp; resourceScheme == file || !inSearchEditor &amp;&amp; explorerViewletFocus"
-}
-</t>
+  "when": "config.leoIntegration.leoCollapseAllShortcut &amp;&amp; !inSearchEditor &amp;&amp; !sideBarFocus &amp;&amp; resourceScheme == untitled || config.leoIntegration.leoCollapseAllShortcut &amp;&amp; !inSearchEditor &amp;&amp; !sideBarFocus &amp;&amp; resourceScheme == file || config.leoIntegration.leoCollapseAllShortcut &amp;&amp; !inSearchEditor &amp;&amp; explorerViewletFocus"
+},
+{
+  "command": "workbench.view.extension.leoIntegrationView",
+  "key": "ctrl+shift+l",
+  "when": "config.leoIntegration.leoActivityViewShortcut &amp;&amp; !inSearchEditor &amp;&amp; focusedView != workbench.view.search"
+}</t>
 <t tx="felix.20210816230003.1">## 0.1.17
 
 - Saves recently opened Leo files list per workspace, instead of globally.
@@ -18886,9 +18902,12 @@ body &gt; div &gt; div &gt; label:active {
           is an open-source extension created by
           &lt;a class="bold"
              title="My github user page"
-             href="https://boltex.github.io/"&gt;Félix&lt;/a&gt; that integrates &lt;a class="bold"
+             href="https://boltex.github.io/"&gt;Félix&lt;/a&gt;
+          that integrates
+          &lt;a class="bold"
              title="Learn more about Leo"
-             href="https://leoeditor.com/"&gt;Leo&lt;/a&gt; into VS Code.
+             href="https://leoeditor.com/"&gt;Leo&lt;/a&gt;
+          into VS Code.
           &lt;!--
           LeoInteg is designed to &lt;b&gt;provide Leo's functionality&lt;/b&gt;
           and can be &lt;b&gt;customized&lt;/b&gt; to meet your needs.

--- a/package.json
+++ b/package.json
@@ -96,6 +96,18 @@
           "type": "boolean",
           "description": "Specifies whether to keep focus in the outline when opening a body pane on the side"
         },
+        "leoIntegration.leoCollapseAllShortcut": {
+          "scope": "application",
+          "default": true,
+          "type": "boolean",
+          "description": "Enables the alt+minus keyboard shortcut for collapsing all folders in the Explorer View"
+        },
+        "leoIntegration.leoActivityViewShortcut": {
+          "scope": "application",
+          "default": true,
+          "type": "boolean",
+          "description": "Enables the Ctrl+Shift+L keyboard shortcut for showing the LeoIntegration view"
+        },
         "leoIntegration.statusBarColor": {
           "scope": "application",
           "default": "fb7c47",
@@ -3812,7 +3824,12 @@
       {
         "command": "workbench.files.action.collapseExplorerFolders",
         "key": "alt+-",
-        "when": "!inSearchEditor && !sideBarFocus && resourceScheme == untitled || !inSearchEditor && !sideBarFocus && resourceScheme == file || !inSearchEditor && explorerViewletFocus"
+        "when": "config.leoIntegration.leoCollapseAllShortcut && !inSearchEditor && !sideBarFocus && resourceScheme == untitled || config.leoIntegration.leoCollapseAllShortcut && !inSearchEditor && !sideBarFocus && resourceScheme == file || config.leoIntegration.leoCollapseAllShortcut && !inSearchEditor && explorerViewletFocus"
+      },
+      {
+        "command": "workbench.view.extension.leoIntegrationView",
+        "key": "ctrl+shift+l",
+        "when": "config.leoIntegration.leoActivityViewShortcut && !inSearchEditor && focusedView != workbench.view.search"
       }
     ],
     "resourceLabelFormatters": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,10 @@ export class Config implements ConfigMembers {
     public leoTreeBrowse: boolean = Constants.CONFIG_DEFAULTS.LEO_TREE_BROWSE;
     public treeKeepFocus: boolean = Constants.CONFIG_DEFAULTS.TREE_KEEP_FOCUS;
     public treeKeepFocusWhenAside: boolean = Constants.CONFIG_DEFAULTS.TREE_KEEP_FOCUS_WHEN_ASIDE;
+
+    public leoCollapseAllShortcut: boolean = Constants.CONFIG_DEFAULTS.COLLAPSE_ALL_SHORTCUT;
+    public leoActivityViewShortcut: boolean = Constants.CONFIG_DEFAULTS.ACTIVITY_VIEW_SHORTCUT;
+
     // public statusBarString: string = Constants.CONFIG_DEFAULTS.STATUSBAR_STRING;
     public statusBarColor: string = Constants.CONFIG_DEFAULTS.STATUSBAR_COLOR;
     public treeInExplorer: boolean = Constants.CONFIG_DEFAULTS.TREE_IN_EXPLORER;
@@ -70,6 +74,10 @@ export class Config implements ConfigMembers {
             leoTreeBrowse: this.leoTreeBrowse,
             treeKeepFocus: this.treeKeepFocus,
             treeKeepFocusWhenAside: this.treeKeepFocusWhenAside,
+
+            leoCollapseAllShortcut: this.leoCollapseAllShortcut,
+            leoActivityViewShortcut: this.leoActivityViewShortcut,
+
             // statusBarString: this.statusBarString,
             statusBarColor: this.statusBarColor,
             treeInExplorer: this.treeInExplorer,
@@ -287,6 +295,10 @@ export class Config implements ConfigMembers {
             this.leoTreeBrowse = GET(NAME).get(NAMES.LEO_TREE_BROWSE, DEFAULTS.LEO_TREE_BROWSE);
             this.treeKeepFocus = GET(NAME).get(NAMES.TREE_KEEP_FOCUS, DEFAULTS.TREE_KEEP_FOCUS);
             this.treeKeepFocusWhenAside = GET(NAME).get(NAMES.TREE_KEEP_FOCUS_WHEN_ASIDE, DEFAULTS.TREE_KEEP_FOCUS_WHEN_ASIDE);
+
+            this.leoCollapseAllShortcut = GET(NAME).get(NAMES.COLLAPSE_ALL_SHORTCUT, DEFAULTS.COLLAPSE_ALL_SHORTCUT);
+            this.leoActivityViewShortcut = GET(NAME).get(NAMES.ACTIVITY_VIEW_SHORTCUT, DEFAULTS.ACTIVITY_VIEW_SHORTCUT);
+
             // this.statusBarString = GET(NAME).get(NAMES.STATUSBAR_STRING, DEFAULTS.STATUSBAR_STRING);
             // if (this.statusBarString.length > 8) {
             //     this.statusBarString = DEFAULTS.STATUSBAR_STRING;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -270,8 +270,13 @@ export class Constants {
         LEO_TREE_BROWSE: "leoTreeBrowse",
         TREE_KEEP_FOCUS: "treeKeepFocus",
         TREE_KEEP_FOCUS_WHEN_ASIDE: "treeKeepFocusWhenAside",
-        STATUSBAR_STRING: "statusBarString",
+
+        COLLAPSE_ALL_SHORTCUT: "leoCollapseAllShortcut",
+        ACTIVITY_VIEW_SHORTCUT: "leoActivityViewShortcut",
+
+        // STATUSBAR_STRING: "statusBarString",
         STATUSBAR_COLOR: "statusBarColor",
+
         TREE_IN_EXPLORER: "treeInExplorer",
         SHOW_OPEN_ASIDE: "showOpenAside",
         SHOW_EDIT: "showEditOnNodes",
@@ -314,7 +319,11 @@ export class Constants {
         LEO_TREE_BROWSE: true,
         TREE_KEEP_FOCUS: true,
         TREE_KEEP_FOCUS_WHEN_ASIDE: false,
-        STATUSBAR_STRING: "", // Strings like "Literate", "Leo", UTF-8 also supported: \u{1F981}
+
+        COLLAPSE_ALL_SHORTCUT: true,
+        ACTIVITY_VIEW_SHORTCUT: true,
+
+        // STATUSBAR_STRING: "", // Strings like "Literate", "Leo", UTF-8 also supported: \u{1F981}
         STATUSBAR_COLOR: "fb7c47",
         TREE_IN_EXPLORER: true,
         SHOW_OPEN_ASIDE: true,

--- a/src/leoIntegration.ts
+++ b/src/leoIntegration.ts
@@ -1001,7 +1001,6 @@ export class LeoIntegration {
                                 }
                                 if (w_indexToSelect >= 0) {
                                     // found it!
-                                    console.log('found it!', w_indexToSelect);
 
                                     // Select from list if present, by index with "set opened file"
                                     return this.sendAction(

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,8 +18,13 @@ export interface ConfigMembers {
     leoTreeBrowse: boolean;
     treeKeepFocus: boolean;
     treeKeepFocusWhenAside: boolean;
+
+    leoCollapseAllShortcut: boolean;
+    leoActivityViewShortcut: boolean;
+
     // statusBarString: string;
     statusBarColor: string;
+
     treeInExplorer: boolean;
     showOpenAside: boolean;
     showEditOnNodes: boolean;

--- a/src/webviews/settingsPanel/index.html
+++ b/src/webviews/settingsPanel/index.html
@@ -61,9 +61,12 @@
           is an open-source extension created by
           <a class="bold"
              title="My github user page"
-             href="https://boltex.github.io/">Félix</a> that integrates <a class="bold"
+             href="https://boltex.github.io/">Félix</a>
+          that integrates
+          <a class="bold"
              title="Learn more about Leo"
-             href="https://leoeditor.com/">Leo</a> into VS Code.
+             href="https://leoeditor.com/">Leo</a>
+          into VS Code.
           <!--
           LeoInteg is designed to <b>provide Leo's functionality</b>
           and can be <b>customized</b> to meet your needs.
@@ -283,7 +286,7 @@
               </div>
               <span class="setting__hint">Keep focus in the outline when selecting a node - overridden by "<strong>Leo
                   Tree
-                  Browsing"</strong></span>
+                  Browsing</strong>"</span>
             </div>
 
             <div class="setting">
@@ -295,6 +298,32 @@
                 <label for="treeKeepFocusWhenAside">Keep focus when opening on the side</label>
               </div>
               <span class="setting__hint">Keep focus in the outline when opening a body pane on the side</span>
+            </div>
+
+            <div class="break"></div>
+
+            <div class="setting">
+              <div class="setting__input">
+                <input id="leoCollapseAllShortcut"
+                       name="leoCollapseAllShortcut"
+                       type="checkbox"
+                       data-setting />
+                <label for="leoCollapseAllShortcut">Enable collapse-all shortcut for explorer</label>
+              </div>
+              <span class="setting__hint">Allows the <strong>[alt+'-'] keyboard shortcut</strong>
+                to collapse folders in the file explorer</span>
+            </div>
+
+            <div class="setting">
+              <div class="setting__input">
+                <input id="leoActivityViewShortcut"
+                       name="leoActivityViewShortcut"
+                       type="checkbox"
+                       data-setting />
+                <label for="leoActivityViewShortcut">Enable 'Show LeoInteg view' shortcut</label>
+              </div>
+              <span class="setting__hint">Allows the <strong>[Ctrl+Shift+L] keyboard shortcut</strong>
+                to reveal the Leointeg Activity View</span>
             </div>
 
           </div>
@@ -342,6 +371,7 @@
             </p>
           </div>
         </div>
+        <div class="break"></div> <!-- Make sure to break line after this short title. -->
         <div class="section__preview">
           <img class="image__preview"
                src="#{root}/resources/showOpenAsideDisabled.png" />

--- a/src/webviews/settingsPanel/scss/main.scss
+++ b/src/webviews/settingsPanel/scss/main.scss
@@ -1075,6 +1075,11 @@ fieldset {
   // justify-content: space-between;
 }
 
+.break {
+  flex-basis: 100%;
+  height: 0;
+}
+
 .settings--fixed {
   display: block;
 }


### PR DESCRIPTION
Fixes #271